### PR TITLE
Add accessnri::yamanifest to payu/dev environment

### DIFF
--- a/environments/payu-dev/environment.yml
+++ b/environments/payu-dev/environment.yml
@@ -17,3 +17,4 @@ dependencies:
   - xarray
   - mule
   - um2nc
+  - accessnri::yamanifest


### PR DESCRIPTION
Added `accessnri::yamanifest` to pick up the latest version of `yamanifest` from the `access-nri` conda channel. 
Closes #6 