### PR TITLE
Add payu environment deploy script to update the default payu module

### DIFF
--- a/environments/payu/deploy.sh
+++ b/environments/payu/deploy.sh
@@ -1,12 +1,8 @@
-# UNCOMMENT once payu is moved out of pre-release as default payu module in prerelease should remain payu/dev
+## Update stable if necessary
+CURRENT_STABLE=$( get_aliased_module "${MODULE_NAME}" "${MODULE_PATH}" )
+NEXT_STABLE="${ENVIRONMENT}-${STABLE_VERSION}"
 
-### Update stable if necessary
-# CURRENT_STABLE=$( get_aliased_module "${MODULE_NAME}" "${MODULE_PATH}" )
-# NEXT_STABLE="${ENVIRONMENT}-${STABLE_VERSION}"
-
-# if ! [[ "${CURRENT_STABLE}" == "${MODULE_NAME}/${STABLE_VERSION}" ]]; then
-#     echo "Updating stable environment to ${NEXT_STABLE}"
-#     write_modulerc_stable "${STABLE_VERSION}" "${ENVIRONMENT}" "${CONDA_MODULE_PATH}" "${MODULE_NAME}"
-#     symlink_atomic_update "${CONDA_INSTALLATION_PATH}"/envs/"${ENVIRONMENT}" "${NEXT_STABLE}"
-#     symlink_atomic_update "${CONDA_SCRIPT_PATH}"/"${ENVIRONMENT}".d "${NEXT_STABLE}".d
-# fi
+if ! [[ "${CURRENT_STABLE}" == "${MODULE_NAME}/${STABLE_VERSION}" ]]; then
+    echo "Updating default environment to ${NEXT_STABLE}"
+    write_modulerc_stable "${STABLE_VERSION}" "default" "${CONDA_MODULE_PATH}" "${MODULE_NAME}"
+fi


### PR DESCRIPTION
Uncommenting the payu deploy script as `payu/1.1.6` is getting deployed to a release location. This checks that the module loaded by `module load payu` is `module load payu/${STABLE_VERSION}`. To set a new default version it creates a `.modulerc` file at `/g/data/vk83/modules/payu` with: 

```
#%Module1.0

module-version payu/1.1.6 default
```

Tested the custom deploy script with deploying to a directory with pre-existing payu modules and it loads `payu/1.1.6` when running `module load payu`.

Updated the `Gadi` Github environment `CONDA_BASE` to `/g/data/vk83` (was `/g/data/vk83/prerelease` - the same as `Gadi Prerelease`) and `ADMIN_DIR` to `/g/data/vk83/testing/admin/conda_containers/release`.



