### PR TITLE
Move conda environment vars to the launcher scripts

### DIFF
--- a/container/container.def
+++ b/container/container.def
@@ -39,4 +39,9 @@ Bootstrap: scratch
         mkdir -p ${SINGULARITY_ROOTFS}/var/run/munge
 
 %runscript
-        /usr/bin/bash -l
+        if [ -z "${CONDA_BASE}" ]; then
+            echo "CONDA_BASE is not set. Skipping activating conda environment"
+        else
+            source ${CONDA_BASE}/bin/activate
+        fi
+        exec "$@"

--- a/environments/payu-dev/deploy.sh
+++ b/environments/payu-dev/deploy.sh
@@ -24,9 +24,12 @@ for old_version in $old_versions; do
         continue
     fi
 
-    # Remove modulefiles and module insert
+    # Remove modulefile
     unlink "${CONDA_MODULE_PATH}"/"${old_version}"
-    rm "${CONDA_MODULE_PATH}"/."${old_version}"
+    # Remove moduefile insert if it exists
+    if [ -f "${CONDA_MODULE_PATH}"/."${old_version}" ]; then
+        rm "${CONDA_MODULE_PATH}"/."${old_version}"
+    fi
     # Remove launcher script directories
     rm -rf "${CONDA_SCRIPT_PATH}"/"${ENVIRONMENT}"-"${old_version}".d
     # Remove squashfs file

--- a/modules/common_v4
+++ b/modules/common_v4
@@ -1,0 +1,30 @@
+#%Module1.0
+
+set prefix __CONDA_BASE__/__APPS_SUBDIR__
+set package __CONDA_INSTALL_BASENAME__
+
+# Prevent running this module with a running payu module
+conflict payu
+
+# Name of this module's environment
+lassign [split [module-info name] {/}] module_name module_version
+set condaenv "${module_version}"
+set basedir "$prefix/$package/envs/$condaenv"
+if {![ file exists $basedir ]} {
+    # For modulenames which are $ENVIRONMENT/$VERSION, rather than conda/$ENIRONMENT-$VERSION
+    set condaenv "${module_name}-${module_version}"
+    set basedir "$prefix/$package/envs/$condaenv"
+}
+
+set myscripts [ file normalize __CONDA_BASE__/__SCRIPT_SUBDIR__/$condaenv.d/bin ]
+set overlay_path [ string map {/conda/ /envs/} $basedir ].sqsh
+
+module load singularity
+
+prepend-path CONTAINER_OVERLAY_PATH $overlay_path
+
+# Add launcher script directory to PATH
+prepend-path PATH $myscripts
+
+### Extra env to get other things working
+setenv OMPI_MCA_orte_launch_agent $myscripts/orted

--- a/modules/common_v4
+++ b/modules/common_v4
@@ -6,6 +6,11 @@ set package __CONDA_INSTALL_BASENAME__
 # Prevent running this module with a running payu module
 conflict payu
 
+# Warn if another conda environment is already loaded
+if { [info exists env(CONDA_DEFAULT_ENV)] } {
+    puts stderr "Warning: Another conda environment is currently loaded (CONDA_DEFAULT_ENV: $env(CONDA_DEFAULT_ENV))"
+}
+
 # Name of this module's environment
 lassign [split [module-info name] {/}] module_name module_version
 set condaenv "${module_version}"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -113,13 +113,23 @@ function inner() {
     done
     popd
 
+    ### Set up the environment activate script
+    cat > "${CONDA_INSTALLATION_PATH}/envs/${FULLENV}/bin/activate" <<EOF
+export PATH=${CONDA_INSTALLATION_PATH}/envs/${FULLENV}/bin:\$PATH
+for config in "${CONDA_INSTALLATION_PATH}/envs/${FULLENV}/etc/conda/activate.d/*.sh"; do
+    if [ -r "\$config" ]; then
+        source "\$config"
+    fi
+done
+EOF
+
     ### Update any supporting infrastructure
     copy_if_changed "${SCRIPT_DIR}"/launcher.sh "${CONDA_SCRIPT_PATH}"/launcher.sh
     for override in "${SCRIPT_DIR}"/overrides/*; do
         copy_if_changed "${override}" "${CONDA_SCRIPT_PATH}"/overrides/"${override##*/}"
     done
     mkdir -p "${CONDA_MODULE_PATH}"
-    copy_and_replace "${SCRIPT_DIR}"/../modules/common_v3 "${CONDA_MODULE_PATH}"/.common_v3       CONDA_BASE APPS_SUBDIR CONDA_INSTALL_BASENAME SCRIPT_SUBDIR
+    copy_and_replace "${SCRIPT_DIR}"/../modules/"${COMMON_MODULEFILE}" "${CONDA_MODULE_PATH}"/."${COMMON_MODULEFILE}"       CONDA_BASE APPS_SUBDIR CONDA_INSTALL_BASENAME SCRIPT_SUBDIR
     copy_and_replace "${SCRIPT_DIR}"/launcher_conf.sh     "${CONDA_SCRIPT_PATH}"/launcher_conf.sh CONDA_BASE APPS_SUBDIR CONDA_INSTALL_BASENAME
 
     ### Create symlink tree
@@ -225,7 +235,7 @@ fi
 
 
 if [[ "${DO_UPDATE}" == "--install" ]]; then
-    ln -s .common_v3 "${CONDA_OUTER_BASE}"/"${MODULE_SUBDIR}"/"${MODULE_NAME}"/"${MODULE_VERSION}"
+    ln -s ."${COMMON_MODULEFILE}" "${CONDA_OUTER_BASE}"/"${MODULE_SUBDIR}"/"${MODULE_NAME}"/"${MODULE_VERSION}"
 fi
 
 pushd "${CONDA_TEMP_PATH}"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -256,10 +256,6 @@ fi
 rm "${CONDA_OUTER_BASE}"/"${APPS_SUBDIR}"/"${CONDA_INSTALL_BASENAME}"/envs/"${FULLENV}"
 ln -s /opt/conda/"${FULLENV}" "${CONDA_OUTER_BASE}"/"${APPS_SUBDIR}"/"${CONDA_INSTALL_BASENAME}"/envs/
 
-### Can't use ${CONDA_SCRIPT_PATH} or "${CONDA_INSTALLATION_PATH}" due to the need to string match on those paths
-### which they won't with the '/./' part required for arcane rsync magic
-construct_module_insert "${SINGULARITY_BINARY_PATH}" "${OVERLAY_BASE}" "${my_container}" "${BUILD_STAGE_DIR}"/"${FULLENV}".sqsh.tmp "${SCRIPT_DIR}"/condaenv.sh "${CONDA_INSTALLATION_PATH}" /opt/conda/"${FULLENV}" "${CONDA_BASE}"/"${SCRIPT_SUBDIR}"/"${FULLENV}".d/bin "${CONDA_OUTER_BASE}"/"${MODULE_SUBDIR}"/"${MODULE_NAME}"/."${MODULE_VERSION}"
-
 ### Set permissions on base environment
 set_apps_perms "${CONDA_OUTER_BASE}"
 

--- a/scripts/dev_prep.sh
+++ b/scripts/dev_prep.sh
@@ -47,7 +47,7 @@ _inner() {
     for override in "${SCRIPT_DIR}"/overrides/*; do
         copy_if_changed "${override}" "${CONDA_SCRIPT_PATH}"/overrides/"${override##*/}"
     done
-    copy_and_replace_if_changed "${SCRIPT_DIR}"/../modules/common_v3 "${CONDA_MODULE_PATH}"/.common_v3       CONDA_BASE APPS_SUBDIR CONDA_INSTALL_BASENAME SCRIPT_SUBDIR
+    copy_and_replace_if_changed "${SCRIPT_DIR}"/../modules/"${COMMON_MODULEFILE}" "${CONDA_MODULE_PATH}"/."${COMMON_MODULEFILE}"       CONDA_BASE APPS_SUBDIR CONDA_INSTALL_BASENAME SCRIPT_SUBDIR
     copy_and_replace_if_changed "${SCRIPT_DIR}"/launcher_conf.sh     "${CONDA_SCRIPT_PATH}"/launcher_conf.sh CONDA_BASE APPS_SUBDIR CONDA_INSTALL_BASENAME
 
     ### Create symlink tree

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -121,57 +121,6 @@ function symlink_atomic_update() {
     set_apps_perms "${link_name}"
 }
 
-function construct_module_insert() {
-
-    singularity_exec="${1}"
-    overlay_path="${2}"
-    container_path="${3}"
-    squashfs_path="${4}"
-    env_script="${5}"
-    rootdir="${6}"
-    condaenv="${7}"
-    script_path="${8}"
-    module_path="${9}"
-
-    declare -a discard_paths=( "/bin" "/usr/bin" "/condabin" )
-    declare -a discard_vars=( "MODULEPATH" "_" "PWD" "SHLVL" )
-
-    while read line; do
-        key="${line%%=*}"
-        value="${line#*=}"
-        ### Skip these environment variables
-        in_array "${discard_vars[@]}" "${key}" && continue
-        ### Prepend to these variables
-        if [[ $key =~ .PATH$ ]]; then
-            echo prepend-path $key $value
-        ### Prepend to Modulefile variables that work like a path
-        elif in_array "_LMFILES_" "LOADEDMODULES" "${key}"; then
-            echo prepend-path $key $value
-        ### Treat path specially - remove system paths and retain order
-        elif [[ "${key}" == "PATH" ]]; then
-            while IFS= read -r -d: entry; do
-                in_array "${discard_paths[@]}" "${entry}" && continue
-                if [[ $entry =~ $condaenv ]]; then
-                    echo prepend-path PATH $script_path
-                else
-                    echo prepend-path PATH $entry
-                fi
-                echo prepend-path SINGULARITYENV_PREPEND_PATH $entry
-            done<<<"${value%:}:"
-        elif [[ "${key}" =~ ^alias\  ]]; then
-            echo set-alias "${key//alias /}" "${value//\'/}"
-        else
-            if [[ "${value}" ]]; then
-                echo setenv $key \"$value\"
-            else
-                echo setenv $key \"\"
-            fi
-        fi
-
-    done < <( "${singularity_exec}" -s exec --bind /etc,/half-root,/local,/ram,/run,/system,/usr,/var/lib/sss,/var/run/munge,/var/lib/rpm,"${overlay_path}":/g --overlay="${squashfs_path}"  "${container_path}" /bin/env -i "${env_script}" "${rootdir}" "${condaenv}" ) > "${module_path}"
-
-}
-
 function copy_and_replace() {
     ### Copies the file in $1 to the location in $2 and replaces any occurence
     ### of __${3}__, __${4}__... with the contents of those environment variables

--- a/scripts/install_config.sh
+++ b/scripts/install_config.sh
@@ -37,6 +37,9 @@ export CONDA_INSTALL_BASENAME="base_conda" #TODO: Eventually replace with conda
 # so payu modules are named payu/$MODULE_VERSION (e.g. payu/1.1.5)
 export MODULE_NAME="conda"
 
+# Common modulefile to use for conda environments
+export COMMON_MODULEFILE="common_v4"
+
 ### Derived locations - extra '.' for arcane rsync magic
 export CONDA_SCRIPT_PATH="${CONDA_BASE}"/./"${SCRIPT_SUBDIR}"
 export CONDA_MODULE_PATH="${CONDA_BASE}"/./"${MODULE_SUBDIR}"/"${MODULE_NAME}"

--- a/scripts/launcher.sh
+++ b/scripts/launcher.sh
@@ -161,5 +161,8 @@ bind_str=${bind_str%,}
 
 $debug "binding args= " ${bind_str}
 
+# Disable using local python libraries inside the container
+export SINGULARITYENV_PYTHONNOUSERSITE="x"
+
 $debug "Singularity invocation: " "$SINGULARITY_BINARY_PATH" -s exec --bind "${bind_str}" ${overlay_args} "${CONTAINER_PATH}" "${cmd_to_run[@]}"
 "$SINGULARITY_BINARY_PATH" -s exec --bind "${bind_str}" ${overlay_args} "${CONTAINER_PATH}" "${cmd_to_run[@]}"

--- a/scripts/launcher.sh
+++ b/scripts/launcher.sh
@@ -106,6 +106,7 @@ fi
 
 $debug "CONTAINER_OVERLAY_PATH after override check = " ${CONTAINER_OVERLAY_PATH}
 
+# Note: CONDA_BASE is used in the container runscript to activate the conda environment
 export CONDA_BASE="${CONDA_BASE_ENV_PATH}/envs/${myenv}"
 
 if ! [[ -x "${SINGULARITY_BINARY_PATH}" ]]; then
@@ -164,5 +165,6 @@ $debug "binding args= " ${bind_str}
 # Disable using local python libraries inside the container
 export SINGULARITYENV_PYTHONNOUSERSITE="x"
 
-$debug "Singularity invocation: " "$SINGULARITY_BINARY_PATH" -s exec --bind "${bind_str}" ${overlay_args} "${CONTAINER_PATH}" "${cmd_to_run[@]}"
-"$SINGULARITY_BINARY_PATH" -s exec --bind "${bind_str}" ${overlay_args} "${CONTAINER_PATH}" "${cmd_to_run[@]}"
+# Using `singularity run` so the runscript in the container is run
+$debug "Singularity invocation: " "$SINGULARITY_BINARY_PATH" -s run --bind "${bind_str}" ${overlay_args} "${CONTAINER_PATH}" "${cmd_to_run[@]}"
+"$SINGULARITY_BINARY_PATH" -s run --bind "${bind_str}" ${overlay_args} "${CONTAINER_PATH}" "${cmd_to_run[@]}"


### PR DESCRIPTION
This PR:
- Sets `PYTHONNOUSERSITE` inside the container using `SINGULARITYENV_PYTHONNOUSERSITE` in the launcher script.
- Invoke singularity using `singularity run` then activate the environment with the `%runscript` in the container definition which runs when the container is launched. 
- Add a new version of the modulefile which removes all conda-specific environment variables.

`PYTHONNOUSERSITE` is set in the launcher script instead of the common modulefile so this gets set when running a launcher script directly without prior loading the module  (e.g. when payu directly runs from a launcher script on the compute nodes).

I used Scott Wales's example of activating an environment in a `%runscript` and adding an activate script to the built environment (https://git.nci.org.au/bom/ngm/conda-container/-/blob/master/base/base.def#L5 and https://git.nci.org.au/bom/ngm/conda-container/-/blob/master/build.sh#L61). This means when using `singularity run`, it will activate the environment once the container is launched. Modifying the container with a `%runscript` won't actually modify pre-existing deployments as they are run with `singularity exec` which runs the command directly.

Added the new version of modulefile `common_v4` to prevent breaking changes with pre-existing deployments as all the conda specific environment settings are removed.

Closes #12
Closes #11 