### PR TITLE
Set PYTHONNOUSERSITE inside the container in launch script

### DIFF
--- a/scripts/launcher.sh
+++ b/scripts/launcher.sh
@@ -161,6 +161,9 @@ bind_str=${bind_str%,}
 
 $debug "binding args= " ${bind_str}
 
+# Disable using local python libraries inside the container
+export SINGULARITYENV_PYTHONNOUSERSITE="x"
+
 function singularity_exec () {
     $debug "Singularity invocation: " "$SINGULARITY_BINARY_PATH" -s exec --bind "${bind_str}" ${overlay_args} "${CONTAINER_PATH}" "${cmd_to_run[@]}"
     "$SINGULARITY_BINARY_PATH" -s exec --bind "${bind_str}" ${overlay_args} "${CONTAINER_PATH}" "${cmd_to_run[@]}"


### PR DESCRIPTION
PYTHONNOUSERSITE is set to prevent conflicts with local installed versions of payu. This is set in the launcher script so this gets set when running a launcher script directly without prior loading the module (e.g. when payu directly runs from a launcher script on the compute nodes).

Closes #12