### PR TITLE
Keep 5 latest versions of payu/dev

### DIFF
--- a/environments/payu-dev/deploy.sh
+++ b/environments/payu-dev/deploy.sh
@@ -10,8 +10,8 @@ write_modulerc_stable "${VERSION_TO_MODIFY}" "dev" "${CONDA_MODULE_PATH}" "${MOD
 ### Remove old payu-dev versions
 payu_dev_versions=$(ls "${CONDA_MODULE_PATH}" | grep -E '^dev-[0-9]{8}T[0-9]{6}Z-.*')
 # Order module versions by date (versions format is dev-DATETIME-COMMIT),
-# and remove the 2 latest versions (e.g. current and previous)
-old_versions=$(echo "$payu_dev_versions" | sort -r | tail -n +3)
+# and remove the 5 latest versions (We are keeping the latest versions incase of any currently running payu pbs jobs)
+old_versions=$(echo "$payu_dev_versions" | sort -r | tail -n +6)
 
 for old_version in $old_versions; do
     # Double check for empty strings to avoid deleting everything


### PR DESCRIPTION
Moved this from #20. This PR changes the deploy script to only keep the 5 latest versions of `payu/dev` instead of latest 2 versions. Basically there was a case where the latest `payu/dev` was broken so we had to point to a earlier version of `payu/dev` - However if we deploy a new version, it would then delete the previous working version which may currently be used in PBS run jobs and keep the broken version.

I went with last 5 just to be super safe if there's multiple `payu/dev` deployments in quick succession and to avoid breaking any long running payu jobs. As the environments are squashfs files, having several environments shouldn't use that many inodes. 