### PR TITLE
Set  PYTHONDONTWRITEBYTECODE

### DIFF
--- a/scripts/launcher.sh
+++ b/scripts/launcher.sh
@@ -164,6 +164,9 @@ $debug "binding args= " ${bind_str}
 # Disable using local python libraries inside the container
 export SINGULARITYENV_PYTHONNOUSERSITE="x"
 
+# Disable Python's bytecode cache inside the container
+export SINGULARITYENV_PYTHONDONTWRITEBYTECODE="1"
+
 function singularity_exec () {
     $debug "Singularity invocation: " "$SINGULARITY_BINARY_PATH" -s exec --bind "${bind_str}" ${overlay_args} "${CONTAINER_PATH}" "${cmd_to_run[@]}"
     "$SINGULARITY_BINARY_PATH" -s exec --bind "${bind_str}" ${overlay_args} "${CONTAINER_PATH}" "${cmd_to_run[@]}"


### PR DESCRIPTION
Try setting `PYTHONDONTWRITEBYTECODE` inside the container.

I've already run some tests with this setting on a test `payu/1.1.7` environment deployed to my account and compared it to the existing `payu/1.1.7` on vk83. I ran a number of PBS jobs with repeated imports used in a um2nc netCDF post-processing job for both versions of the environment. There was perhaps a slight time performance improvement of 2%. The environment with `PYTHONDONTWRITEBYTECODE` got 2 transient import errors in the tests vs 11 in the other environment - so it doesn't completely fix the issue but still worth adding it in. 

Once this is merged, I'll redeploy an `payu/dev` so this change gets added in. 

Closes  #23 