### PR TITLE
Support environment with restricted commands

### DIFF
--- a/environments/payu-dev/config.sh
+++ b/environments/payu-dev/config.sh
@@ -28,3 +28,14 @@ declare -a replace_from_apps=()
 declare -a outside_commands_to_include=( "pbs_tmrsh" )
 declare -a outside_files_to_copy=()
 declare -a replace_with_external=()
+
+declare -a launcher_commands=(
+    "payu-run"
+    "payu-collate"
+    "payu-sync"
+    "payu"
+    "payu-branch"
+    "payu-checkout"
+    "payu-clone"
+    "payu-profile"
+)

--- a/modules/common_cmd_v1
+++ b/modules/common_cmd_v1
@@ -1,0 +1,32 @@
+#%Module1.0
+
+set prefix __CONDA_BASE__/__APPS_SUBDIR__
+set package __CONDA_INSTALL_BASENAME__
+
+# Prevent running this module with a running payu module
+conflict payu
+
+# Name of this module's environment
+lassign [split [module-info name] {/}] module_name module_version
+if {[string match *-lite $module_version]} {
+    # Remove the '-lite' suffix for the conda environment name
+    set condaenv_version [string range $module_version 0 end-5]
+} else {
+    set condaenv_version $module_version
+}
+set basedir "$prefix/$package/envs/$condaenv_version"
+if {![ file exists $basedir ]} {
+    # For modulenames which are $ENVIRONMENT/$VERSION-lite, rather than conda/$ENIRONMENT-$VERSION-lite
+    set condaenv "${module_name}-${condaenv_version}"
+    set basedir "$prefix/$package/envs/$condaenv"
+}
+
+set myscripts [ file normalize __CONDA_BASE__/__SCRIPT_SUBDIR__/$condaenv-lite.d/bin ]
+set overlay_path [ string map {/conda/ /envs/} $basedir ].sqsh
+
+module load singularity
+
+prepend-path CONTAINER_OVERLAY_PATH $overlay_path
+
+# Add launcher script directory to PATH
+prepend-path PATH $myscripts

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -120,9 +120,10 @@ function inner() {
     done
     mkdir -p "${CONDA_MODULE_PATH}"
     copy_and_replace "${SCRIPT_DIR}"/../modules/common_v3 "${CONDA_MODULE_PATH}"/.common_v3       CONDA_BASE APPS_SUBDIR CONDA_INSTALL_BASENAME SCRIPT_SUBDIR
-    copy_and_replace "${SCRIPT_DIR}"/launcher_conf.sh "${CONDA_SCRIPT_PATH}"/launcher_conf.sh CONDA_BASE APPS_SUBDIR CONDA_INSTALL_BASENAME CONDA_SCRIPT_PATH FULLENV
+    copy_and_replace "${SCRIPT_DIR}"/../modules/common_cmd_v1 "${CONDA_MODULE_PATH}"/.common_cmd_v1       CONDA_BASE APPS_SUBDIR CONDA_INSTALL_BASENAME SCRIPT_SUBDIR
+    copy_and_replace "${SCRIPT_DIR}"/launcher_conf.sh "${CONDA_SCRIPT_PATH}"/launcher_conf.sh CONDA_BASE APPS_SUBDIR CONDA_INSTALL_BASENAME
 
-    ### Create symlink tree
+    ### Create symlink tree for full environment
     mkdir -p "${CONDA_SCRIPT_PATH}"/"${FULLENV}".d/{bin,overrides}
     cp "${CONDA_SCRIPT_PATH}"/{launcher.sh,launcher_conf.sh} "${CONDA_SCRIPT_PATH}"/"${FULLENV}".d/bin
     pushd "${CONDA_SCRIPT_PATH}"/"${FULLENV}".d/bin
@@ -142,6 +143,29 @@ function inner() {
         ln -s ${i}
     done
     popd
+
+    ### Create symlink tree for lite environment with limited launcher commands
+    if [ "${#launcher_commands[@]}" -gt 0 ]; then
+        mkdir -p "${CONDA_SCRIPT_PATH}"/"${FULLENV}"-lite.d/{bin,overrides}
+        cp "${CONDA_SCRIPT_PATH}"/{launcher.sh,launcher_conf.sh} "${CONDA_SCRIPT_PATH}"/"${FULLENV}"-lite.d/bin
+        pushd "${CONDA_SCRIPT_PATH}"/"${FULLENV}"-lite.d/bin
+        for cmd in "${launcher_commands[@]}"; do
+            ln -s launcher.sh $cmd
+        done
+
+        ### Add in the outside commands
+        for i in "${outside_commands_to_include[@]}"; do
+            ln -s launcher.sh $i
+        done
+        popd
+
+        ### Add in the override and config scripts
+        pushd "${CONDA_SCRIPT_PATH}"/"${FULLENV}-lite".d/overrides
+        for i in ../../overrides/*; do
+            ln -s ${i}
+        done
+        popd
+    fi
 
     if [[ -e "${SCRIPT_DIR}"/../environments/"${CONDA_ENVIRONMENT}"/build_inner.sh ]]; then
         source "${SCRIPT_DIR}"/../environments/"${CONDA_ENVIRONMENT}"/build_inner.sh
@@ -226,6 +250,9 @@ fi
 
 if [[ "${DO_UPDATE}" == "--install" ]]; then
     ln -s .common_v3 "${CONDA_OUTER_BASE}"/"${MODULE_SUBDIR}"/"${MODULE_NAME}"/"${MODULE_VERSION}"
+    if [ "${#launcher_commands[@]}" -gt 0 ]; then
+        ln -s .common_cmd_v1 "${CONDA_OUTER_BASE}"/"${MODULE_SUBDIR}"/"${MODULE_NAME}"/"${MODULE_VERSION}"-lite
+    fi
 fi
 
 pushd "${CONDA_TEMP_PATH}"
@@ -250,6 +277,9 @@ ln -s /opt/conda/"${FULLENV}" "${CONDA_OUTER_BASE}"/"${APPS_SUBDIR}"/"${CONDA_IN
 ### which they won't with the '/./' part required for arcane rsync magic
 construct_module_insert "${SINGULARITY_BINARY_PATH}" "${OVERLAY_BASE}" "${my_container}" "${BUILD_STAGE_DIR}"/"${FULLENV}".sqsh.tmp "${SCRIPT_DIR}"/condaenv.sh "${CONDA_INSTALLATION_PATH}" /opt/conda/"${FULLENV}" "${CONDA_BASE}"/"${SCRIPT_SUBDIR}"/"${FULLENV}".d/bin "${CONDA_OUTER_BASE}"/"${MODULE_SUBDIR}"/"${MODULE_NAME}"/."${MODULE_VERSION}"
 construct_launcher_insert "${SINGULARITY_BINARY_PATH}" "${OVERLAY_BASE}" "${my_container}" "${BUILD_STAGE_DIR}"/"${FULLENV}".sqsh.tmp "${SCRIPT_DIR}"/condaenv.sh "${CONDA_INSTALLATION_PATH}" /opt/conda/"${FULLENV}" "${CONDA_BASE}"/"${SCRIPT_SUBDIR}"/"${FULLENV}".d/bin "${CONDA_OUTER_BASE}"/"${SCRIPT_SUBDIR}"/"${FULLENV}".d/bin/launcher_activate.sh
+if [ "${#launcher_commands[@]}" -gt 0 ]; then
+    cp "${CONDA_OUTER_BASE}"/"${SCRIPT_SUBDIR}"/"${FULLENV}".d/bin/launcher_activate.sh "${CONDA_OUTER_BASE}"/"${SCRIPT_SUBDIR}"/"${FULLENV}"-lite.d/bin/launcher_activate.sh
+fi
 
 ### Set permissions on base environment
 set_apps_perms "${CONDA_OUTER_BASE}"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -249,6 +249,7 @@ ln -s /opt/conda/"${FULLENV}" "${CONDA_OUTER_BASE}"/"${APPS_SUBDIR}"/"${CONDA_IN
 ### Can't use ${CONDA_SCRIPT_PATH} or "${CONDA_INSTALLATION_PATH}" due to the need to string match on those paths
 ### which they won't with the '/./' part required for arcane rsync magic
 construct_module_insert "${SINGULARITY_BINARY_PATH}" "${OVERLAY_BASE}" "${my_container}" "${BUILD_STAGE_DIR}"/"${FULLENV}".sqsh.tmp "${SCRIPT_DIR}"/condaenv.sh "${CONDA_INSTALLATION_PATH}" /opt/conda/"${FULLENV}" "${CONDA_BASE}"/"${SCRIPT_SUBDIR}"/"${FULLENV}".d/bin "${CONDA_OUTER_BASE}"/"${MODULE_SUBDIR}"/"${MODULE_NAME}"/."${MODULE_VERSION}"
+construct_launcher_insert "${SINGULARITY_BINARY_PATH}" "${OVERLAY_BASE}" "${my_container}" "${BUILD_STAGE_DIR}"/"${FULLENV}".sqsh.tmp "${SCRIPT_DIR}"/condaenv.sh "${CONDA_INSTALLATION_PATH}" /opt/conda/"${FULLENV}" "${CONDA_BASE}"/"${SCRIPT_SUBDIR}"/"${FULLENV}".d/bin "${CONDA_OUTER_BASE}"/"${SCRIPT_SUBDIR}"/"${FULLENV}".d/bin/launcher_activate.sh
 
 ### Set permissions on base environment
 set_apps_perms "${CONDA_OUTER_BASE}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -36,6 +36,9 @@ rsync --archive --verbose --partial --progress --one-file-system --itemize-chang
 
 echo "Make sure anything deleted from this environments scripts directory is also deleted from the prod copy"
 rsync --archive --verbose --partial --progress --one-file-system --itemize-changes --hard-links --acls --relative --delete -- "${CONDA_TEMP_PATH}"/"${APPS_SUBDIR}"/./"${CONDA_SCRIPTS_BASENAME}"/"${FULLENV}".d "${CONDA_BASE}"/"${APPS_SUBDIR}"
+if [ "${#launcher_commands[@]}" -gt 0 ]; then
+    rsync --archive --verbose --partial --progress --one-file-system --itemize-changes --hard-links --acls --relative --delete -- "${CONDA_TEMP_PATH}"/"${APPS_SUBDIR}"/./"${CONDA_SCRIPTS_BASENAME}"/"${FULLENV}"-lite.d "${CONDA_BASE}"/"${APPS_SUBDIR}"
+fi
 
 [[ -e "${CONDA_INSTALLATION_PATH}"/envs/"${FULLENV}".sqsh ]] && cp "${CONDA_INSTALLATION_PATH}"/envs/"${FULLENV}".sqsh "${ADMIN_DIR}"/"${FULLENV}".sqsh.bak
 mv "${BUILD_STAGE_DIR}"/"${FULLENV}".sqsh.tmp "${CONDA_INSTALLATION_PATH}"/envs/"${FULLENV}".sqsh

--- a/scripts/launcher.sh
+++ b/scripts/launcher.sh
@@ -29,8 +29,14 @@ $debug "conf_file = " "${conf_file}"
 
 source "${conf_file}"
 
+# Set up the environment launcher script path - useful for scripts, such as payu,
+# to know how launch the container directly
+export ENV_LAUNCHER_SCRIPT_PATH="${wrapper_bin%/}"/launcher.sh
+$debug "ENV_LAUNCHER_SCRIPT_PATH = " "${ENV_LAUNCHER_SCRIPT_PATH}"
+
 # Check if conda environment already activated
 myenv=$( basename "${wrapper_bin%/*}" ".d" )
+myenv="${myenv%-lite}"
 if [[ "${CONDA_DEFAULT_ENV}" != "/opt/conda/${myenv}" ]]; then
     activate_script="${wrapper_bin}"/launcher_activate.sh
     $debug "activate_script = " "${activate_script}"

--- a/scripts/launcher_conf.sh
+++ b/scripts/launcher_conf.sh
@@ -5,7 +5,3 @@ export CONTAINER_PATH="__CONDA_BASE__/__APPS_SUBDIR__/__CONDA_INSTALL_BASENAME__
 export CONDA_BASE_ENV_PATH="__CONDA_BASE__/__APPS_SUBDIR__/__CONDA_INSTALL_BASENAME__"
 
 declare -a bind_dirs=( "/etc" "/half-root" "/local" "/ram" "/run" "/system" "/usr" "/var/lib/sss" "/var/run/munge" "/sys/fs/cgroup" "/iointensive" )
-
-# Set up the environment launcher script path - useful for scripts, such as payu,
-# to know how launch the container directly
-export ENV_LAUNCHER_SCRIPT_PATH="__CONDA_SCRIPT_PATH__/__FULLENV__.d/bin/launcher.sh"


### PR DESCRIPTION
Overall issue we are trying to solve is running these containers alongside conda environments. One way is to not activate the environment via the module file and restrict external launcher script commands to only the tool (e.g. `payu`).

To avoid activating the environment in the modulefile in 738442c, I tried replicating the modulefile insert that activates the conda environment - but instead write a script that be run as part of a launcher script. I don't think my solution here is that good. Alternative solutions to activate the environment in the launcher scripts could be:

- Run command using micromamba command directly, e.g.
`${CONDA_EXE} run --prefix "${CONDA_BASE_ENVIRONMENT}" "${cmd_to_run[@]}"`. A downside is that none of the environments are currently dependent on the micromamba install at runtime as it's only used to create the environments, and this would add in that dependency.
- Create an activate script within the environment and run it every time the command inside the environment runs (similar to this [previous PR](https://github.com/ACCESS-NRI/model-release-condaenv/pull/13)).
- Have the environment module insert instead set `SINGULARITYENV_*` variables so they are only set when container is launched. This might have an issue when multiple modules that set `SINGULARITYENV_*` are loaded at the same time, and it'll use the most recently loaded module values.

In c96af86, I'm creating `-lite` version of the module that only activates the environment in the launcher script and exposes a limited set of commands. So there would a `payu/$version` module, which works similar to before, and a `payu/$version-lite` module. Both modules use the same `squashfs` environment file. So it wouldn't add too much in terms of storage. The idea of keeping the original environment module is because it's used for creating virtual environments.

This PR shouldn't be merged as hopefully there's a cleaner solution, and it is not necessary until the payu environment has limited tools installed which are only needed for running payu.








