### PR TITLE
Pin git and openssh

### DIFF
--- a/environments/payu-dev/environment.yml
+++ b/environments/payu-dev/environment.yml
@@ -13,7 +13,8 @@ dependencies:
   - git==2.46.0
   - nco
   - pytest
-  - openssh>=8.3
+  - openssh==10.0p1
+  - openssl==3.5.2
   - xarray
   - mule
   - um2nc

--- a/environments/payu-dev/environment.yml
+++ b/environments/payu-dev/environment.yml
@@ -10,7 +10,7 @@ dependencies:
     - git+https://github.com/payu-org/payu.git@master
   - f90nml
   - gh
-  - git
+  - git==2.46.0
   - nco
   - pytest
   - openssh>=8.3


### PR DESCRIPTION
Related to #34

This downgrades git to a version that doesn't error out when cloning from local clones (as brought up in linked issue).

It also pins `openssh` and `openssl` versions as `openssl` had a version update recently which raises errors when git cloning with ssh. 