### PR TITLE
Un-pin git version in payu/dev

### DIFF
--- a/environments/payu-dev/environment.yml
+++ b/environments/payu-dev/environment.yml
@@ -10,7 +10,7 @@ dependencies:
     - git+https://github.com/payu-org/payu.git@master
   - f90nml
   - gh
-  - git==2.46.0
+  - git
   - nco
   - pytest
   - openssh==10.0p1


### PR DESCRIPTION
Related to #34

Reverting pinning the git version as it was not causing the issues with git cloning from another user's home directory (see https://github.com/ACCESS-NRI/model-release-condaenv/issues/34#issuecomment-3326349572)