### PR TITLE
Disable payu telemetry

### DIFF
--- a/scripts/launcher_conf.sh
+++ b/scripts/launcher_conf.sh
@@ -4,7 +4,8 @@ export CONTAINER_PATH="__CONDA_BASE__/__APPS_SUBDIR__/__CONDA_INSTALL_BASENAME__
 
 export CONDA_BASE_ENV_PATH="__CONDA_BASE__/__APPS_SUBDIR__/__CONDA_INSTALL_BASENAME__"
 
-export PAYU_TELEMETRY_CONFIG="__PAYU_TELEMETRY_CONFIG__"
+# Enables telemetry in Payu
+# export PAYU_TELEMETRY_CONFIG="__PAYU_TELEMETRY_CONFIG__"
 
 declare -a bind_dirs=( "/etc" "/half-root" "/local" "/ram" "/run" "/system" "/usr" "/var/lib/sss" "/var/run/munge" "/sys/fs/cgroup" "/iointensive" )
 


### PR DESCRIPTION
This PR removes the environment variable in the payu launcher script that tells payu to look for a telemetry configuration file and send telemetry.

Once merged, manually deploy a new payu/dev environment to pick up this change: 
https://github.com/ACCESS-NRI/model-release-condaenv/actions/workflows/deploy_payu_dev.yml

