### PR TITLE
Add mnctools to payu release

### DIFF
--- a/environments/payu/environment.yml
+++ b/environments/payu/environment.yml
@@ -20,3 +20,4 @@ dependencies:
   - netcdf4=*=nompi_*
   - experiment-generator
   - experiment-runner
+  - mnctools


### PR DESCRIPTION
Add `mnctools` to payu release. Intention is to overwrite the existing deployment, so version is unchanged.

Fixes #39 