### PR TITLE
Add addmeta to payu release environment

### DIFF
--- a/environments/payu/environment.yml
+++ b/environments/payu/environment.yml
@@ -21,3 +21,4 @@ dependencies:
   - experiment-generator
   - experiment-runner
   - mnctools
+  - addmeta


### PR DESCRIPTION
Add addmeta to payu release environment when testing in `payu/dev` complete. Closes #43 