### PR TITLE
payu-dev: Allow errors importing backports.zstd._cffi in tests

### DIFF
--- a/environments/payu-dev/testconfig.yml
+++ b/environments/payu-dev/testconfig.yml
@@ -96,3 +96,4 @@ exception:
 - fontTools.ufoLib #
 - pandas.core._numba.kernels #
 - scipy._lib.array_api_compat.cupy #
+- backports.zstd._cffi #


### PR DESCRIPTION
Test allowing errors on imports when loading `backports.zstd._cffi` in tests. 
Closes #47 