### PR TITLE
launcher script: Default to not retry singularity cmds on login nodes

### DIFF
--- a/scripts/launcher.sh
+++ b/scripts/launcher.sh
@@ -175,20 +175,18 @@ function singularity_exec () {
 # On login nodes, retry is set to 0 as not capturing stderr preserves interactive sessions
 # and it should be straight-forward to retry a command
 DEFAULT_MAX_RETRY=0
-if [[ -n "${PBS_JOBID}" ]]; then
+if [[ -n "$PBS_JOBID" ]]; then
    # Default to one retry when running command on PBS jobs
    DEFAULT_MAX_RETRY=1
 fi
 
 # Allow override from environment
-MAX_RETRY="${ENV_LAUNCHER_SCRIPT_MAX_RETRY:-${DEFAULT_MAX_RETRY}}"
+MAX_ATTEMPTS=$(( 1 + ${ENV_LAUNCHER_SCRIPT_MAX_RETRY:-$DEFAULT_MAX_RETRY} ))
 
 exit_code=0
 
-for ((attempt=0; attempt<=MAX_RETRY; attempt++)); do
-    last_attempt=$(( attempt == MAX_RETRY ))
-
-    if (( MAX_RETRY == 0 || last_attempt )); then
+for attempt in $(seq 1 $MAX_ATTEMPTS); do 
+    if [ attempt -eq $MAX_ATTEMPTS ]; then
         # Run command without capturing stderr
         singularity_exec
         exit_code=$?
@@ -200,11 +198,11 @@ for ((attempt=0; attempt<=MAX_RETRY; attempt++)); do
         {out}>&-
 
         # Write to stderr
-        echo "${error_msg}" 1>&2
+        echo "$error_msg" >&2
 
-        if [[ $exit_code == 255 ]] && [[ $error_msg =~ "container creation failed" ]]; then
+        if [[ $exit_code == 255 && "$error_msg" == *'container creation failed'* ]]; then
             # Transient container failure with error code 255: Retry
-            echo "Singularity invocation attempt ${attempt} failed." >&2
+            echo "Singularity invocation attempt $attempt failed." >&2
             echo "Re-trying singularity invocation." >&2
         else
             # Do not retry when successful execution and other errors occurred

--- a/scripts/launcher.sh
+++ b/scripts/launcher.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Validation check for retry environment variable
+if [[ -n "$ENV_LAUNCHER_SCRIPT_MAX_RETRY" && ! $ENV_LAUNCHER_SCRIPT_MAX_RETRY =~ ^[0-9]+$ ]]; then
+    echo "Env variable 'ENV_LAUNCHER_SCRIPT_MAX_RETRY' must be a non-negative integer." >&2
+    exit 1
+fi
+
 function in_array() {
     ### Assumes first n-1 args are an array and final arg is the string to search for
     ### Necessary because [[ libab =~ liba ]] returns true
@@ -183,10 +189,8 @@ fi
 # Allow override from environment
 MAX_ATTEMPTS=$(( 1 + ${ENV_LAUNCHER_SCRIPT_MAX_RETRY:-$DEFAULT_MAX_RETRY} ))
 
-exit_code=0
-
 for attempt in $(seq 1 $MAX_ATTEMPTS); do 
-    if [ attempt -eq $MAX_ATTEMPTS ]; then
+    if [ "$attempt" -eq $MAX_ATTEMPTS ]; then
         # Run command without capturing stderr
         singularity_exec
         exit_code=$?


### PR DESCRIPTION
This PR references #58 

Add default to not retrying and capture stderr for singularity exec commands on the login node. When retrying the `singularity exec` command, it uses similar logic to capture stderr.

 Adds an option to override the default retry number with `ENV_LAUNCHER_SCRIPT_MAX_RETRY`.

<details>
  <summary>I've tested this change with a minimal(ish..) launcher script that uses a deployed environment</summary>

It is a bit hacky and it grabs code it needs to run from the current launcher script.
```
#!/usr/bin/env bash
# set -x

# Path to this script (TODO make this dynamic)
export ENV_LAUNCHER_SCRIPT_PATH=/scratch/tm70/$USER/test_launcher/launcher_script_pbs.sh

# Pre-existing environment values
export SINGULARITYENV_PREPEND_PATH=/opt/conda/payu-dev-20260127T142550Z-9fd4f71/bin
export CONDA_DEFAULT_ENV=/opt/conda/payu-dev-20260127T142550Z-9fd4f71


export SINGULARITYENV_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
declare -a singularity_default_path=( '/usr/local/sbin' '/usr/local/bin' '/usr/sbin' '/usr/bin' '/sbin' '/bin' )

function in_array() {
    ### Assumes first n-1 args are an array and final arg is the string to search for
    ### Necessary because [[ libab =~ liba ]] returns true
    declare -a allargs=( "$@" )
    finalarg=${allargs[$(( ${#allargs[@]} - 1 ))]}
    for (( j=0; j<$(( ${#allargs[@]} - 1 )); j++ )); do
        [[ "${allargs[$j]}" == "${finalarg}" ]] && return 0
    done
    return 1
}

while IFS= read -r -d: i; do
    in_array "${singularity_default_path[@]}" "${i}" && continue
    [[ "${i}" == "/opt/singularity/bin" ]] && continue
    SINGULARITYENV_PREPEND_PATH="${SINGULARITYENV_PREPEND_PATH}:${i}"
done<<<"${PATH%:}:"
export SINGULARITYENV_PREPEND_PATH=${SINGULARITYENV_PREPEND_PATH#:*}

# Build command array
declare -a PROG_ARGS=( "$@" )
cmd_to_run=( "${PROG_ARGS[@]}" )


function singularity_exec () {
  /opt/singularity/bin/singularity \
    -s \
    exec \
    --bind /etc,/half-root,/local,/ram,/run,/system,/usr,/var/lib/sss,/var/run/munge,/sys/fs/cgroup,/iointensive \
    --overlay=/g/data/vk83/prerelease/apps/base_conda/envs/payu-dev-20260127T142550Z-9fd4f71.sqsh \
    /g/data/vk83/apps/base_conda/etc/base.sif \
    "${cmd_to_run[@]}"
}

DEFAULT_MAX_RETRY=0
if [[ -n "${PBS_JOBID}" ]]; then
   # Default to one retry when running command on PBS jobs
   DEFAULT_MAX_RETRY=1
fi

# Allow override from environment
MAX_RETRY="${ENV_LAUNCHER_SCRIPT_MAX_RETRY:-${DEFAULT_MAX_RETRY}}"

exit_code=0

for ((attempt=0; attempt<=MAX_RETRY; attempt++)); do
    last_attempt=$(( attempt == MAX_RETRY ))

    if (( MAX_RETRY == 0 || last_attempt )); then
        # Run command without capturing STDERR
        singularity_exec
        exit_code=$?
        break
    else
        # Run the singularity exec command. Capture stderr for error handling
        { error_msg=$(singularity_exec 2>&1 1>&$out); exit_code=$?; } {out}>&1
        # Close additional file descriptor
        {out}>&-

        # Write to stderr
        echo "${error_msg}" 1>&2

        if [[ $exit_code == 255 ]] && [[ $error_msg =~ "container creation failed" ]]; then
            # Transient container failure with error code 255: Retry
            echo "Singularity invocation attempt ${attempt} failed." >&2
            echo "Re-trying singularity invocation." >&2
        elif [[ $exit_code == 2 ]] && [[ $error_msg =~ 'No such file or directory' ]]; then
            echo "Singularity invocation attempt ${attempt} failed." >&2
            echo "Re-trying singularity invocation." >&2
        else
            # Avoid retrying for other errors
            break
        fi
    fi
done

exit $exit_code
```
</details>