### PR TITLE
Use new apptainer singularity install to avoid transient errors

### DIFF
--- a/modules/common_v3
+++ b/modules/common_v3
@@ -21,7 +21,7 @@ set overlay_path [ string map {/conda/ /envs/} $basedir ].sqsh
 
 set launcher $myscripts/launcher.sh
 
-module load singularity
+module load apptainer
 
 prepend-path CONTAINER_OVERLAY_PATH $overlay_path
 prepend-path SINGULARITYENV_PREPEND_PATH $basedir/condabin

--- a/modules/common_v4
+++ b/modules/common_v4
@@ -21,7 +21,7 @@ set overlay_path [ string map {/conda/ /envs/} $basedir ].sqsh
 
 set launcher $myscripts/launcher.sh
 
-module load singularity
+module load apptainer
 
 prepend-path CONTAINER_OVERLAY_PATH $overlay_path
 prepend-path SINGULARITYENV_PREPEND_PATH $basedir/condabin

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -119,7 +119,7 @@ function inner() {
         copy_if_changed "${override}" "${CONDA_SCRIPT_PATH}"/overrides/"${override##*/}"
     done
     mkdir -p "${CONDA_MODULE_PATH}"
-    copy_and_replace "${SCRIPT_DIR}"/../modules/common_v3 "${CONDA_MODULE_PATH}"/.common_v3       CONDA_BASE APPS_SUBDIR CONDA_INSTALL_BASENAME SCRIPT_SUBDIR
+    copy_and_replace "${SCRIPT_DIR}"/../modules/"${COMMON_MODULEFILE}" "${CONDA_MODULE_PATH}"/."${COMMON_MODULEFILE}"       CONDA_BASE APPS_SUBDIR CONDA_INSTALL_BASENAME SCRIPT_SUBDIR
     copy_and_replace "${SCRIPT_DIR}"/launcher_conf.sh "${CONDA_SCRIPT_PATH}"/launcher_conf.sh CONDA_BASE APPS_SUBDIR CONDA_INSTALL_BASENAME CONDA_SCRIPT_PATH FULLENV PAYU_TELEMETRY_CONFIG
 
     ### Create symlink tree
@@ -225,7 +225,7 @@ fi
 
 
 if [[ "${DO_UPDATE}" == "--install" ]]; then
-    ln -s .common_v3 "${CONDA_OUTER_BASE}"/"${MODULE_SUBDIR}"/"${MODULE_NAME}"/"${MODULE_VERSION}"
+    ln -s ."${COMMON_MODULEFILE}" "${CONDA_OUTER_BASE}"/"${MODULE_SUBDIR}"/"${MODULE_NAME}"/"${MODULE_VERSION}"
 fi
 
 pushd "${CONDA_TEMP_PATH}"

--- a/scripts/install_config.sh
+++ b/scripts/install_config.sh
@@ -37,6 +37,9 @@ export CONDA_INSTALL_BASENAME="base_conda" #TODO: Eventually replace with conda
 # so payu modules are named payu/$MODULE_VERSION (e.g. payu/1.1.5)
 export MODULE_NAME="conda"
 
+# Common modulefile to use for conda environments
+export COMMON_MODULEFILE="common_v4"
+
 ### Derived locations - extra '.' for arcane rsync magic
 export CONDA_SCRIPT_PATH="${CONDA_BASE}"/./"${SCRIPT_SUBDIR}"
 export CONDA_MODULE_PATH="${CONDA_BASE}"/./"${MODULE_SUBDIR}"/"${MODULE_NAME}"

--- a/scripts/install_config.sh
+++ b/scripts/install_config.sh
@@ -57,7 +57,7 @@ fi
 export TEST_OUT_FILE=test_results.xml
 export PYTHONNOUSERSITE=true
 export CONTAINER_PATH="${SCRIPT_DIR}"/../container/base.sif
-export SINGULARITY_BINARY_PATH="/opt/singularity/bin/singularity"
+export SINGULARITY_BINARY_PATH="/opt/nci/apptainer/bin/singularity"
 
 declare -a bind_dirs=( "/etc" "/half-root" "/local" "/ram" "/run" "/system" "/usr" "/var/lib/sss" "/var/lib/rpm" "/var/run/munge" "/sys/fs/cgroup" "/iointensive" )
 

--- a/scripts/launcher.sh
+++ b/scripts/launcher.sh
@@ -114,8 +114,8 @@ $debug "CONTAINER_OVERLAY_PATH after override check = " ${CONTAINER_OVERLAY_PATH
 
 export CONDA_BASE="${CONDA_BASE_ENV_PATH}/envs/${myenv}"
 
-if [[ $(awk '/NoNewPrivs/ {print $2}' /proc/self/status) -ne 0 ]]; then
-    ### Short circuit detection - check process status (0 if running out outside a container)
+if [[ -n "$APPTAINER_CONTAINER" ]]; then
+    ### Short circuit detection - check if APPTAINER_CONTAINER environment var is non-empty
     ### In some cases (e.g. mpi processes launched from orterun), launcher will be invoked from
     ### within the container. 
     ### The only way this can happen is if we've tried to run something that has come

--- a/scripts/launcher.sh
+++ b/scripts/launcher.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-# Validation check for retry environment variable
-if [[ -n "$ENV_LAUNCHER_SCRIPT_MAX_RETRY" && ! $ENV_LAUNCHER_SCRIPT_MAX_RETRY =~ ^[0-9]+$ ]]; then
-    echo "Env variable 'ENV_LAUNCHER_SCRIPT_MAX_RETRY' must be a non-negative integer." >&2
-    exit 1
-fi
-
 function in_array() {
     ### Assumes first n-1 args are an array and final arg is the string to search for
     ### Necessary because [[ libab =~ liba ]] returns true
@@ -173,46 +167,6 @@ export SINGULARITYENV_PYTHONNOUSERSITE="x"
 # Disable Python's bytecode cache inside the container
 export SINGULARITYENV_PYTHONDONTWRITEBYTECODE="1"
 
-function singularity_exec () {
-    $debug "Singularity invocation: " "$SINGULARITY_BINARY_PATH" -s exec --bind "${bind_str}" ${overlay_args} "${CONTAINER_PATH}" "${cmd_to_run[@]}"
-    "$SINGULARITY_BINARY_PATH" -s exec --bind "${bind_str}" ${overlay_args} "${CONTAINER_PATH}" "${cmd_to_run[@]}"
-}
 
-# On login nodes, retry is set to 0 as not capturing stderr preserves interactive sessions
-# and it should be straight-forward to retry a command
-DEFAULT_MAX_RETRY=0
-if [[ -n "$PBS_JOBID" ]]; then
-   # Default to one retry when running command on PBS jobs
-   DEFAULT_MAX_RETRY=1
-fi
-
-# Allow override from environment
-MAX_ATTEMPTS=$(( 1 + ${ENV_LAUNCHER_SCRIPT_MAX_RETRY:-$DEFAULT_MAX_RETRY} ))
-
-for attempt in $(seq 1 $MAX_ATTEMPTS); do 
-    if [ "$attempt" -eq $MAX_ATTEMPTS ]; then
-        # Run command without capturing stderr
-        singularity_exec
-        exit_code=$?
-        break
-    else
-        # Run the singularity exec command. Capture stderr for error handling
-        { error_msg=$(singularity_exec 2>&1 1>&$out); exit_code=$?; } {out}>&1
-        # Close additional file descriptor
-        {out}>&-
-
-        # Write to stderr
-        echo "$error_msg" >&2
-
-        if [[ $exit_code == 255 && "$error_msg" == *'container creation failed'* ]]; then
-            # Transient container failure with error code 255: Retry
-            echo "Singularity invocation attempt $attempt failed." >&2
-            echo "Re-trying singularity invocation." >&2
-        else
-            # Do not retry when successful execution and other errors occurred
-            break
-        fi
-    fi
-done
-
-exit $exit_code
+$debug "Singularity invocation: " "$SINGULARITY_BINARY_PATH" -s exec --bind "${bind_str}" ${overlay_args} "${CONTAINER_PATH}" "${cmd_to_run[@]}"
+"$SINGULARITY_BINARY_PATH" -s exec --bind "${bind_str}" ${overlay_args} "${CONTAINER_PATH}" "${cmd_to_run[@]}"

--- a/scripts/launcher.sh
+++ b/scripts/launcher.sh
@@ -78,7 +78,7 @@ done
 $debug "PROG_ARGS =" "${PROG_ARGS[@]}"
 
 if ! [[ "${SINGULARITY_BINARY_PATH}" ]]; then
-    module load singularity
+    module load apptainer
     export SINGULARITY_BINARY_PATH=$( type -p singularity )
 fi
 
@@ -114,10 +114,10 @@ $debug "CONTAINER_OVERLAY_PATH after override check = " ${CONTAINER_OVERLAY_PATH
 
 export CONDA_BASE="${CONDA_BASE_ENV_PATH}/envs/${myenv}"
 
-if ! [[ -x "${SINGULARITY_BINARY_PATH}" ]]; then
-    ### Short circuit detection
+if [[ $(awk '/NoNewPrivs/ {print $2}' /proc/self/status) -ne 0 ]]; then
+    ### Short circuit detection - check process status (0 if running out outside a container)
     ### In some cases (e.g. mpi processes launched from orterun), launcher will be invoked from
-    ### within the container. The tell-tale sign for this is if /opt/singularity is missing.
+    ### within the container. 
     ### The only way this can happen is if we've tried to run something that has come
     ### from the bin directory in scripts/env.d/bin/ - the only place these can come from is the
     ### bin directory of the active conda env, so just reset the path to that but keep the 
@@ -144,7 +144,7 @@ declare -a singularity_default_path=( '/usr/local/sbin' '/usr/local/bin' '/usr/s
 
 while IFS= read -r -d: i; do
     in_array "${singularity_default_path[@]}" "${i}" && continue
-    [[ "${i}" == "/opt/singularity/bin" ]] && continue
+    [[ "${i}" == "/opt/nci/apptainer/bin" ]] && continue
     [[ "${i}" == "${wrapper_bin}" ]] && continue
     SINGULARITYENV_PREPEND_PATH="${SINGULARITYENV_PREPEND_PATH}:${i}"
 done<<<"${PATH%:}:"

--- a/scripts/launcher_conf.sh
+++ b/scripts/launcher_conf.sh
@@ -1,5 +1,5 @@
 ### Subject to change
-export SINGULARITY_BINARY_PATH="/opt/singularity/bin/singularity"
+export SINGULARITY_BINARY_PATH="/opt/nci/apptainer/bin/singularity"
 export CONTAINER_PATH="__CONDA_BASE__/__APPS_SUBDIR__/__CONDA_INSTALL_BASENAME__/etc/base.sif"
 
 export CONDA_BASE_ENV_PATH="__CONDA_BASE__/__APPS_SUBDIR__/__CONDA_INSTALL_BASENAME__"

--- a/scripts/overrides/functions.sh
+++ b/scripts/overrides/functions.sh
@@ -11,4 +11,4 @@ function findreal {
 }
 
 ### Subject to change
-export SINGULARITY_BINARY_PATH=/opt/singularity/bin/singularity
+export SINGULARITY_BINARY_PATH=/opt/nci/apptainer/bin/singularity


### PR DESCRIPTION
NCI have recently installed an Apptainer-based container engine on Gadi, which uses a different driver for mounting container image. In most cases it will require just swapping `module load singularity` with `module load apptainer`. This will hopefully fix the transient errors (see #26) and so far no errors have surfaced in my local testing. It could be good to get this change into at least `payu/dev` so it can be further tested. 

Ben Menadue also picked up that the short-circuit to detect if running inside a container in the launcher scripts doesn't correctly detect Apptainer containers. They suggested a more reliable way would be to inspect that process's status directly:

```
$ cat /proc/self/status | grep NoNewPrivs | awk '{print $2}'
0
```

This will return 0 if running outside a container or 1 if inside. (Or more precisely, 0 if launching a container will work and 1 if it won't.)

So far in my tests, there hasn't been any "FATAL:   container creation failed" using apptainer, so we could maybe also remove that retry logic when launching the container? 
