### PR TITLE
pauy-dev: Skip tests for imports in prompt_toolkit.contrib.ssh

### DIFF
--- a/environments/payu-dev/testconfig.yml
+++ b/environments/payu-dev/testconfig.yml
@@ -62,6 +62,7 @@ skip:
 # - torch._inductor
 # - keras.src.backend ### Don't test Keras backends
 # - functorch ### This file has moved to under torch/_functorch. It is not public API.
+ - prompt_toolkit.contrib.ssh # Imports dev dependencies such as asyncssh
 
 # Preload these modules before testing to avoid weird python issues
 preload:


### PR DESCRIPTION
The `payu/dev` tests have: `Error loading prompt_toolkit.contrib.ssh` due to

```
>   import asyncssh
E   ModuleNotFoundError: No module named 'asyncssh'
```

This will be due to `asyncssh` being listed as [dev dependency](https://github.com/prompt-toolkit/python-prompt-toolkit/blob/940af53fa443073d9fdca26d5da6cfe6780f6ac9/pyproject.toml#L35-L36) for `prompt-toolkit`.

I think it is safe to skip the test for the `prompt_toolkit.contrib.ssh` module. 

