### PR TITLE
Remove loading apptainer in module file

### DIFF
--- a/modules/common_v4
+++ b/modules/common_v4
@@ -21,8 +21,6 @@ set overlay_path [ string map {/conda/ /envs/} $basedir ].sqsh
 
 set launcher $myscripts/launcher.sh
 
-module load apptainer
-
 prepend-path CONTAINER_OVERLAY_PATH $overlay_path
 prepend-path SINGULARITYENV_PREPEND_PATH $basedir/condabin
 


### PR DESCRIPTION
This PR removes `apptainer` in the `common_v4` module file. As it seems to run fine without apptainer loaded prior, its a backwards compatible change so doesn't need a new version. 

To test this with a payu environment, I copied and modified the exisiting module file:

```
mkdir -p test_modules/payu
cd test_modules/payu

# Copy module file and environment module insert
cp /g/data/vk83/prerelease/modules/payu/.common_v4 .common_v4
cp /g/data/vk83/prerelease/modules/payu/.dev-20260417T052735Z-00f59e4 .dev-20260417T052735Z-00f59e4
cp /g/data/vk83/prerelease/modules/payu/.modulerc .modulerc

# Create symlink to common module file
ln -s .common_v4 dev-20260417T052735Z-00f59e4

# Modified .common_v4 to remove module load apptainer
# ..

# Load module
module use /path/to/test_modules
module load payu/dev

# Test loading analysis3 doesn't cause conflicts
module use /g/data/xp65/public/modules
module load conda/analysis3
```

I ran a payu configuration and confirmed it was using apptainer on the login node and in the PBS job. 

I think next steps, we can modify `/g/data/vk83/prerelease/modules/payu/.common_v4` to remove this line, check there's no obvious errors and then apply the change to `payu/1.3.0`?

Related to #67 
