### PR TITLE
payu-dev: Skip running tests for pip._vendor.urllib3.contrib.emscripte

### DIFF
--- a/environments/payu-dev/testconfig.yml
+++ b/environments/payu-dev/testconfig.yml
@@ -1,99 +1,27 @@
 # Modules test will not try to import
 skip:
 # # Cause errors and don't throw exceptions cleanly
-# - psutil.tests
  - pandas.io.clipboard
  - matplotlib.backends
-# - pbr.tests
-# - plotly.plotly
-# - bokeh.server.django
 # # Too many, or not necessary
  - iris.tests
  - cartopy.tests
-# - plotly.validators
  - xarray.tests
-# - pyresample.test
-# - pyferret.eofanal
-# - ants.tests
-# - alembic.testing
-# - sqlalchemy.testing
-# - httpx
-# - sanic
-# - tests # random tests from black?
-#  # - cupy # Disable when testing locally
-#  # - cupyx # ditto
-#  # - nci_intake_catalogue # ditto
-#  # - wrf # Prints garbage at v1.3.2.5
  - matplotlib.tests # No test data
-# - prometheus_client.twisted # No twisted
-# - pyface
-# - qt
-# - traits
-# - traitsui
-# - vtk
  - pyparsing
-# - tensorflow_estimator
-# - acs_replica_intake  # can't load catalogue file
-# - access_nri_intake  # can't load catalogue file
-# - pip._vendor.chardet # encounters a null byte, doesn't seem to be an error
-# - pykrige # AttributeError: module 'scipy.linalg' has no attribute 'pinv2' -- rk4417
-# # for both hdbscan and cosima_cookbook see https://accessdev.nci.org.au/jenkins/job/conda/job/analysis3-unstable/1351/consoleFull
-# - hdbscan # test errors but can import
-# - cosima_cookbook  # test error 
-#   #- plotnine # can't import fails on "import matplotlib._contour as _contour" which seems to work otherwise
-#   #- nctoolkit # calls plotnine
-# - xgboost.spark ### Don't think we support spark as a parallel backend
-# - send2trash.mac ### Gadi is not a mac
-# - send2trash.win ### Nor is it windows
-# - attrdict ### Deprecated but still erroneously bought in by wavespectra - not used by anything else
-# - skimage.future.graph ### Thanks for raising a module error to tell me that you've moved this
-# - numba.core.rvsdg_frontend ### Not supported in Python3.10
-# - xgboost.testing ### Has an 'pytest.importorskip' call when imported, causing the whole thing to report skipped
  - scipy._lib.array_api_compat.torch ### Don't support pytorch
  - urllib3.contrib.emscripten ### Used for web browser integration and also experimental: https://urllib3.readthedocs.io/en/latest/reference/contrib/emscripten.html
-# - fugue_duckdb ### Optional backend not used by any package in analysis3
-# - fugue_ibis ### Optional backend not used by any package in analysis3
-# - fugue_polars ### Optional backend not used by any package in analysis3
-# - fugue_ray ### Optional backend not used by any package in analysis3
-# - fugue_spark ### Optional backend not used by any package in analysis3
-# - torch.onnx ### Prevent testing of _internal APIs
-# - torch.testing ### Prevent testing of _internal APIs
-# - torch.utils.benchmark ### Uses non-existent part of deprecated pkg_resources
-# - torch._inductor
-# - keras.src.backend ### Don't test Keras backends
-# - functorch ### This file has moved to under torch/_functorch. It is not public API.
  - prompt_toolkit.contrib.ssh # Imports dev dependencies such as asyncssh
+ - pip._vendor.urllib3.contrib.emscripten # Imports js 
 
 # Preload these modules before testing to avoid weird python issues
 preload:
-# - pysal
-# - tables
-# - skimage.data
-# - sklearn
-# - sklearn.covariance
-# - sklearn.manifold
-# - stratify
 - xarray
 - setuptools.command.build_ext ### Strange issue with numba.pycc
 
 # Allow loading, but pass exceptions. When exceptions no longer triggered
 # can remove
 exception:
-# - sqlalchemy.testing.suite
-# - zmq.green
-# - prometheus_client.twisted
-# - sqlalchemy.testing.suite
-# - zmq.backend.cffi
-# - sklearn.mixture
-# - matplotlib.tests
-# - metpy.io     # While Issue #21 unresolved
-# - metpy.plots  # While Issue #21 unresolved
-# - httpx
-# - sanic
-# - pyparsing.diagrams
-# - pysal.explore.esda
-# - pysal.explore.segregation
-# - pysal.model.access
 - fontTools.ufoLib #
 - pandas.core._numba.kernels #
 - scipy._lib.array_api_compat.cupy #


### PR DESCRIPTION
Tests are currently failing for payu-dev with:

```
>   import js  # type: ignore[import-not-found]
E   ModuleNotFoundError: No module named 'js'

/g/data/vk83/prerelease/apps/base_conda/envs/payu-dev-20260506T220105Z-1a08372/lib/python3.10/site-packages/pip/_vendor/urllib3/contrib/emscripten/fetch.py:45: ModuleNotFoundError
```
```
Error loading pip._vendor.urllib3.contrib.emscripten
```

This PR just skips the tests for emscripten