### PR TITLE
payu-dev: restrict um2nc < 2.0.0

### DIFF
--- a/environments/payu-dev/environment.yml
+++ b/environments/payu-dev/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - pytest
   - xarray
   - mule
-  - um2nc
+  - um2nc<2.0.0
   - accessnri::yamanifest
   - netcdf4=*=nompi_*
   - experiment-generator


### PR DESCRIPTION
Restrict `um2nc`<2.0.0 in `payu/dev` module for now.

Related to #70